### PR TITLE
Point links to plugins to the plugin site at plugins.jenkins.io

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -334,7 +334,7 @@ public class ExtensionPointListGenerator {
                                 discover(addModule(new Module(p.latest(), pi.getPluginUrl(), pi.getName()) {
                                     @Override
                                     String getFormattedLink() {
-                                        return "link:" + url + "[" + displayName + ']';
+                                        return "plugin:" + artifact.artifact.artifactId + "[" + displayName + "]";
                                     }
 
                                     @Override


### PR DESCRIPTION
Untested, don't have the crazy amounts of disk space to do this locally. 

Work in progress. I may rewrite history.