### PR TITLE
Simplify display names of plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>jsoup</artifactId>
       <version>1.9.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -174,10 +174,14 @@ public class ExtensionPointListGenerator {
         }
 
         private String simplifyDisplayName(String displayName) {
+            if (displayName.equals("Jenkins Core")) {
+                return displayName;
+            }
+            displayName = StringUtils.removeStartIgnoreCase(displayName, "Jenkins ");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " for Jenkins");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " Plugin");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " Plug-In");
-            displayName = StringUtils.removeStartIgnoreCase(displayName, "Jenkins ");
+            displayName = displayName + " Plugin"; // standardize spelling
             return displayName;
         }
 

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -178,6 +178,7 @@ public class ExtensionPointListGenerator {
                 return displayName;
             }
             displayName = StringUtils.removeStartIgnoreCase(displayName, "Jenkins ");
+            displayName = StringUtils.removeStartIgnoreCase(displayName, "Hudson ");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " for Jenkins");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " Plugin");
             displayName = StringUtils.removeEndIgnoreCase(displayName, " Plug-In");

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -4,6 +4,7 @@ import hudson.util.VersionNumber;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jvnet.hudson.update_center.HudsonWar;
 import org.jvnet.hudson.update_center.MavenArtifact;
 import org.jvnet.hudson.update_center.MavenRepository;
@@ -169,7 +170,15 @@ public class ExtensionPointListGenerator {
         protected Module(MavenArtifact artifact, String url, String displayName) {
             this.artifact = artifact;
             this.url = url;
-            this.displayName = displayName;
+            this.displayName = simplifyDisplayName(displayName);
+        }
+
+        private String simplifyDisplayName(String displayName) {
+            displayName = StringUtils.removeEndIgnoreCase(displayName, " for Jenkins");
+            displayName = StringUtils.removeEndIgnoreCase(displayName, " Plugin");
+            displayName = StringUtils.removeEndIgnoreCase(displayName, " Plug-In");
+            displayName = StringUtils.removeStartIgnoreCase(displayName, "Jenkins ");
+            return displayName;
         }
 
         /**


### PR DESCRIPTION
Before/after of the list on the extensions list index page:
https://gist.github.com/daniel-beck/963af76e6f4e8f374b91009e5346fd1e

Work in progress. I may rewrite history.