### PR TITLE
[INFRA-1219] Replace implementation Javadoc with link to sources

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -108,7 +108,7 @@ public class ExtensionPointListGenerator {
             w.println();
             for (ExtensionSummary e : implementations) {
                 if (e.implementation == null || e.implementation.trim().isEmpty()) {
-                    w.println("* Anonymous class " + getSynopsis(e));
+                    w.println("* Anonymous class in " + e.packageName + ".**" + e.topLevelClassName + "** " + getSynopsis(e) + " " + getSourceReference(e));
                 } else {
                     w.println("* " + e.packageName + ".**" + e.className + "** " + getSynopsis(e) + " " + getSourceReference(e));
                 }

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -107,28 +107,30 @@ public class ExtensionPointListGenerator {
             w.println("**Implementations:**");
             w.println();
             for (ExtensionSummary e : implementations) {
-                w.println();
-                w.println((e.implementation == null || e.implementation.trim().isEmpty() ? "(Anonymous class)" : e.implementation) + " " + getSynopsis(e) + "::");
-
-                if (e.implementation != null && !e.implementation.trim().isEmpty()) {
-                    // if this is a non-anon class, try to link to it
-                    w.println("+"); // list continuation to make the block as part of the list work
-                    String artifactId = e.artifact.artifact.artifactId;
-                    if (artifactId.equals("jenkins-core")) {
-                        w.println("link:https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/" + e.packageName.replace(".", "/") + "/" + e.topLevelClassName + ".java" + "[view on GitHub]");
-                    } else {
-                        String scmUrl = UpdateCenterUtil.getScmUrlForPlugin(artifactId);
-                        if (scmUrl != null) {
-                            if (scmUrl.contains("github.com")) { // should be limited to GitHub URLs, but best to be safe
-                                w.println("link:" + scmUrl + "/search?q=" + e.className + "[view on GitHub]");
-                            }
-                        }
-                    }
+                if (e.implementation == null || e.implementation.trim().isEmpty()) {
+                    w.println("* Anonymous class " + getSynopsis(e));
+                } else {
+                    w.println("* " + e.packageName + ".**" + e.className + "** " + getSynopsis(e) + " " + getSourceReference(e));
                 }
             }
             if (implementations.isEmpty())
                 w.println("_(no known implementations)_");
             w.println();
+        }
+
+        public String getSourceReference(ExtensionSummary e) {
+            String artifactId = e.artifact.artifact.artifactId;
+            if (artifactId.equals("jenkins-core")) {
+                return "(link:https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/" + e.packageName.replace(".", "/") + "/" + e.topLevelClassName + ".java" + "[view on GitHub])";
+            } else {
+                String scmUrl = UpdateCenterUtil.getScmUrlForPlugin(artifactId);
+                if (scmUrl != null) {
+                    if (scmUrl.contains("github.com")) { // should be limited to GitHub URLs, but best to be safe
+                        return "(link:" + scmUrl + "/search?q=" + e.className + "[view on GitHub])";
+                    }
+                }
+            }
+            return "";
         }
 
         private String formatJavadoc(String javadoc) {
@@ -155,7 +157,7 @@ public class ExtensionPointListGenerator {
             final Module m = modules.get(e.artifact);
             if (m==null)
                 throw new IllegalStateException("Unable to find module for "+e.artifact);
-            return MessageFormat.format("(implemented in {0})", m.getFormattedLink());
+            return MessageFormat.format("implemented in {0}", m.getFormattedLink());
         }
 
         public int compareTo(Object that) {

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -109,11 +109,21 @@ public class ExtensionPointListGenerator {
             for (ExtensionSummary e : implementations) {
                 w.println();
                 w.println((e.implementation == null || e.implementation.trim().isEmpty() ? "(Anonymous class)" : e.implementation) + " " + getSynopsis(e) + "::");
-                w.println("+"); // list continuation to make the block as part of the list work
-                if (e.documentation == null || formatJavadoc(e.documentation).trim().isEmpty()) {
-                    w.println("_This implementation has no Javadoc documentation._");
-                } else {
-                    w.println(formatJavadoc(e.documentation));
+
+                if (e.implementation != null && !e.implementation.trim().isEmpty()) {
+                    // if this is a non-anon class, try to link to it
+                    w.println("+"); // list continuation to make the block as part of the list work
+                    String artifactId = e.artifact.artifact.artifactId;
+                    if (artifactId.equals("jenkins-core")) {
+                        w.println("link:https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/" + e.packageName.replace(".", "/") + "/" + e.topLevelClassName + ".java" + "[view on GitHub]");
+                    } else {
+                        String scmUrl = UpdateCenterUtil.getScmUrlForPlugin(artifactId);
+                        if (scmUrl != null) {
+                            if (scmUrl.contains("github.com")) { // should be limited to GitHub URLs, but best to be safe
+                                w.println("link:" + scmUrl + "/search?q=" + e.className + "[view on GitHub]");
+                            }
+                        }
+                    }
                 }
             }
             if (implementations.isEmpty())

--- a/src/main/java/org/jenkinsci/extension_indexer/UpdateCenterUtil.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/UpdateCenterUtil.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.extension_indexer;
+
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loads update center metadata for use in this tool.
+ *
+ * @author Daniel Beck
+ */
+public class UpdateCenterUtil {
+    private static Map<String, String> pluginToSourceUrlMap = new HashMap<>();
+
+    static {
+        try {
+            URL url = new URL("http://updates.jenkins.io/update-center.actual.json");
+            String json = IOUtils.toString(url.openStream());
+            JSONObject o = JSONObject.fromObject(json);
+            JSONObject plugins = o.getJSONObject("plugins");
+            for (Object key : plugins.keySet()) {
+                try {
+                    String plugin = key.toString();
+                    JSONObject value = plugins.getJSONObject(plugin);
+                    String scm = value.getString("scm");
+                    pluginToSourceUrlMap.put(plugin, scm);
+                } catch (JSONException e) {
+                    // no 'scm' element, expected in some cases
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getScmUrlForPlugin(String plugin) {
+        return pluginToSourceUrlMap.get(plugin);
+    }
+}


### PR DESCRIPTION
Work in progress. Will try PR build results.

This approach links to the actual source file for core (where we can be reasonably sure we'll find the source file), and just to the GitHub search inside the repo for plugins.

Between non-default repo layouts, multimodule Maven projects, Gradle projects, Groovy, Python, Ruby or Scala implementations, guessing source files path and name seems unwise.

Only works for GitHub-hosted plugins as recognized by the update center generator.

Output excerpt:

	hudson.tasks.Maven (implemented in link:https://github.com/jenkinsci/jenkins/[Jenkins Core])::
	+
	link:https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/tasks/Maven.java[view on GitHub]

	hudson.tasks.Shell (implemented in link:https://github.com/jenkinsci/jenkins/[Jenkins Core])::
	+
	link:https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/tasks/Shell.java[view on GitHub]

	com.absint.a3.A3Builder (implemented in plugin:absint-a3[AbsInt a³ Jenkins Plugin])::
	+
	link:https://github.com/jenkinsci/absint-a3-plugin/search?q=A3Builder[view on GitHub]

	com.absint.astree.AstreeBuilder (implemented in plugin:absint-astree[AbsInt Astrée Plugin])::
	+
	link:https://github.com/jenkinsci/absint-astree-plugin/search?q=AstreeBuilder[view on GitHub]

@jglick FYI.