### PR TITLE
Regularly run extensions indexer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,10 @@
 
 properties([
         buildDiscarder(logRotator(numToKeepStr: '5')),
+        pipelineTriggers([
+                // run every Sunday
+                cron('H H * * 0')
+        ])
 ])
 
 node('highmem') {


### PR DESCRIPTION
Right now, there's no regular build of this. Needs to be fixed.

Ideally only for the master branch, but it's not too costly, given that there's typically no PRs around.