### PR TITLE
Enabling maven batch-mode flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node('highmem') {
                 "JAVA_HOME=${tool 'jdk8'}",
                 "PATH+JAVA=${tool 'jdk8'}/bin"
         ]) {
-            sh 'mvn -e clean verify'
+            sh 'mvn -B -e clean verify'
         }
     }
 

--- a/src/main/java/org/jenkinsci/extension_indexer/SourceAndLibs.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/SourceAndLibs.java
@@ -146,6 +146,7 @@ public class SourceAndLibs implements Closeable {
         command.add(process);
         command.addAll(Arrays.asList("--settings", new File("maven-settings.xml").getAbsolutePath()));
         command.addAll(Arrays.asList("--update-snapshots",
+                "--batch-mode",
                 "dependency:copy-dependencies",
                 "-DincludeScope=compile",
                 "-DoutputDirectory=" + destDir.getAbsolutePath()));


### PR DESCRIPTION
In order to reduce unnecessary console output when downloading maven dependencies