### PR TITLE
Use backtick monospace delimiter

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -109,9 +109,9 @@ public class ExtensionPointListGenerator {
             w.println();
             w.println("## " + getShortName().replace(".", ".+++<wbr/>+++"));
             if ("jenkins-core".equals(definition.artifact.artifact.artifactId)) {
-                w.println("+jenkinsdoc:" + definition.extensionPoint + "[]+");
+                w.println("`jenkinsdoc:" + definition.extensionPoint + "[]`");
             } else {
-                w.println("+jenkinsdoc:" + definition.artifact.artifact.artifactId + ":" + definition.extensionPoint + "[]+");
+                w.println("`jenkinsdoc:" + definition.artifact.artifact.artifactId + ":" + definition.extensionPoint + "[]`");
             }
             w.println();
             w.println(definition.documentation == null || formatJavadoc(definition.documentation).trim().isEmpty() ? "_This extension point has no Javadoc documentation._" : formatJavadoc(definition.documentation));

--- a/src/main/resources/org/jenkinsci/extension_indexer/component-preamble.txt
+++ b/src/main/resources/org/jenkinsci/extension_indexer/component-preamble.txt
@@ -3,3 +3,4 @@ layout: developerextension
 uneditable: true
 ---
 :toc:
+:compat-mode!:

--- a/src/main/resources/org/jenkinsci/extension_indexer/index-preamble.txt
+++ b/src/main/resources/org/jenkinsci/extension_indexer/index-preamble.txt
@@ -4,6 +4,7 @@ layout: developerextension
 uneditable: true
 ---
 :toc:
+:compat-mode!:
 
 Jenkins defines extension points, which are interfaces or abstract classes that model an aspect of its behavior.
 Those interfaces define contracts of what need to be implemented, and Jenkins allows plugins to contribute those implementations.


### PR DESCRIPTION
Newer asciidoc uses backtick instead of plus for monospace delimiter.
Related to Related to WEBSITE-428. 