### PR TITLE
Parallelize processing

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -250,7 +250,7 @@ public class ExtensionPointListGenerator {
      */
     private void processPlugins(Collection<JSONObject> plugins) throws Exception {
         int availableProcessors = Runtime.getRuntime().availableProcessors();
-        int nThreads = availableProcessors * 2;
+        int nThreads = availableProcessors * 3;
         System.out.printf("Running with %d threads%n", nThreads);
         ExecutorService svc = Executors.newFixedThreadPool(nThreads);
         try {

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -249,9 +249,12 @@ public class ExtensionPointListGenerator {
      * @param plugins
      */
     private void processPlugins(Collection<JSONObject> plugins) throws Exception {
-        ExecutorService svc = Executors.newFixedThreadPool(1);
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int nThreads = availableProcessors * 2;
+        System.out.printf("Running with %d threads%n", nThreads);
+        ExecutorService svc = Executors.newFixedThreadPool(nThreads);
         try {
-            Set<Future> futures = new HashSet<Future>();
+            Set<Future> futures = new HashSet<>();
             for (final JSONObject plugin : plugins) {
                 final String artifactId = plugin.getString("name");
                 if (!args.isEmpty()) {

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointsExtractor.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointsExtractor.java
@@ -85,14 +85,14 @@ public class ExtensionPointsExtractor {
                 final TypeElement extensionPoint = elements.getTypeElement("hudson.ExtensionPoint");
                 final TypeElement action = elements.getTypeElement("hudson.model.Action");
 
-                public Void visitClass(ClassTree ct, Void _) {
+                public Void visitClass(ClassTree ct, Void ignored) {
                     TreePath path = getCurrentPath();
                     TypeElement e = (TypeElement) trees.getElement(path);
                     if (e != null) {
                         checkIfExtension(path, e, e);
                         checkIfAction(path, e);
                     }
-                    return super.visitClass(ct, _);
+                    return super.visitClass(ct, ignored);
                 }
 
                 /**

--- a/src/main/java/org/jenkinsci/extension_indexer/SourceAndLibs.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/SourceAndLibs.java
@@ -96,7 +96,7 @@ public class SourceAndLibs implements Closeable {
                     if (jf!=null)
                         try {
                             jf.close();
-                        } catch (IOException _) {
+                        } catch (IOException e) {
                         }
                 }
             }


### PR DESCRIPTION
https://github.com/jenkins-infra/backend-extension-indexer/pull/15 back in 2017 changed from running this with 4 threads to making it single threaded.

That lead to slow processing time but made it reliable due to threading issues in commons http client that maven was using, @daniel-beck pasted a thread dump in https://gist.github.com/daniel-beck/401a85db7d58a55b0c78e02d33f971fd

@halkeye removed the affected code in https://github.com/jenkins-infra/backend-extension-indexer/pull/35

Local testing:

| Threads  | Time (minutes) | Notes |
| ------------- | ------------- | ------------- |
| 1  | aborted after 10min  | |
| 4  | aborted after 5min and only being at g  | |
| 8 | 6:11.02  | |
| 10  | 5:15.05  | | 
| 16  | 4:11.23  | |
| 24  | 3:48.70  | |
| 50  | 3:42.13  | |
| 50  | 3:47.13  | Java 17 (compiled with java 8)|
| 50  | 3:39.65  | Java 17 (Shenandoah GC, compiled with java 8) |
| 50  | 3:40.49  | Java 17 (Shenandoah GC, compiled with java 17) |
| 50  | 3:40.31  | Removed println on every plugin, Java 17 (Shenandoah GC, compiled with java 17) |
| 100  | 3:45.03  | |

I haven't done a lot of testing on these numbers but let's see how well it goes


