### PR TITLE
chore: start building pipeline with infra.ci.jenkins.io

### DIFF
--- a/Jenkinsfile.infra.ci.jenkins.io
+++ b/Jenkinsfile.infra.ci.jenkins.io
@@ -28,7 +28,8 @@ node('linux-amd64') {
     }
 
     stage ('Publish') {
-        sh 'zip -r extension-indexer.zip ./dist'
+        // extension-indexer must not include directory name in their zip files
+        sh 'cd dist && zip -r -1 -q ../extension-indexer.zip .'
         if(env.BRANCH_IS_PRIMARY) {
             infra.publishReports(['extension-indexer.zip'])
         } else {

--- a/Jenkinsfile.infra.ci.jenkins.io
+++ b/Jenkinsfile.infra.ci.jenkins.io
@@ -1,0 +1,39 @@
+#!groovy
+// not really
+
+properties([
+        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '5')),
+        pipelineTriggers([
+                // run every Sunday
+                cron('H H * * 0')
+        ])
+])
+
+node('linux-amd64') {
+    stage ('Prepare') {
+        deleteDir()
+        checkout scm
+    }
+
+    stage ('Build') {
+        infra.runMaven(["clean", "verify"], '11')
+    }
+
+    stage ('Generate') {
+        if (infra.isRunningOnJenkinsInfra()) {
+            infra.retrieveMavenSettingsFile( "${pwd}/maven-settings.xml")
+        }
+        infra.runWithMaven('java -jar target/extension-indexer-*-bin/extension-indexer-*.jar -adoc dist', '11')
+    }
+
+    stage ('Publish') {
+        zip dir: './dist', glob: '**', zipFile: 'extension-indexer.zip'
+        if(env.BRANCH_IS_PRIMARY) {
+            infra.publishReports(['extension-indexer.zip'])
+        } else {
+            // On branches and PR, archive the files (there is a buildDiscarder to clean it up) so conributors will be able to check changes
+            archiveArtifacts artifacts: 'extension-indexer.zip'
+        }
+    }
+}

--- a/Jenkinsfile.infra.ci.jenkins.io
+++ b/Jenkinsfile.infra.ci.jenkins.io
@@ -28,7 +28,7 @@ node('linux-amd64') {
     }
 
     stage ('Publish') {
-        zip dir: './dist', glob: '**', zipFile: 'extension-indexer.zip'
+        sh 'zip -r extension-indexer.zip ./dist'
         if(env.BRANCH_IS_PRIMARY) {
             infra.publishReports(['extension-indexer.zip'])
         } else {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3087

Please note that this only add a build to infra.ci (and does not discard ci.jenkins.io current build) for now so we can A/B test the jenkins.io build.

This PR also gets the latest "zip" fixes from @MarkEWaite