### PR TITLE
chore: remove `infra.retrieveMavenSettingsFile`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,6 @@ node('linux-amd64') {
     }
 
     stage ('Generate') {
-        if (infra.isRunningOnJenkinsInfra()) {
-            infra.retrieveMavenSettingsFile( "${pwd}/maven-settings.xml")
-        }
         infra.runWithMaven('java -jar target/extension-indexer-*-bin/extension-indexer-*.jar -adoc dist', '11')
     }
 


### PR DESCRIPTION
The maven-settings.xml in this repo is mirroring every Maven repository to repo.jenkins-ci.org, removing it would not result in a big difference.
This is one of the 2 remaining uses of this function which I intend to remove, and I'll also update `infra.runMaven` to use the Artifact Caching Proxy, with a mirroring of (almost) every Maven repository.