### PR TITLE
Add support for Java 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.87</version>
+    <version>1.98</version>
     <relativePath />
   </parent>
   <artifactId>extension-indexer</artifactId>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
+      <version>1.16.1</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>
-      <version>1.6.3</version>
+      <version>1.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -50,7 +50,7 @@ public class ExtensionPointListGenerator {
      */
     private final Map<String,Family> families = new HashMap<>();
     /**
-     * All the modules we scanned keyed by its {@link Module#artifact}
+     * All the modules we scanned keyed by its {@link Module#artifactId}
      */
     private final Map<String,Module> modules = Collections.synchronizedMap(new HashMap<>());
 

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionSummary.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionSummary.java
@@ -47,8 +47,8 @@ public class ExtensionSummary {
     public final boolean isDefinition;
 
     /**
-     * Family that this extension belongs to. Eithe {@link Family#definition} is 'this'
-     * or {@link Family#implementations} includes 'this'
+     * Family that this extension belongs to. Either {@link Family#definition} is 'this'
+     * or {@code Family#implementations} includes 'this'
      */
     public final Family family;
 


### PR DESCRIPTION
Using recent Java versions to assemble data fails because outdated dependencies don't support Java 20 or newer:
```
[INFO] Fork Value is true
     [java] The following errors occurred during analysis:
     [java]   Error scanning java/lang/Object for referenced classes
     [java]     java.lang.IllegalArgumentException: Unsupported class file major version 64
```
The change proposed updates the affected dependencies and adds to dependabot to keep track of these tasks in the future.