### PR TITLE
Also archive artifacts in infra.ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,13 +34,10 @@ node('linux-amd64') {
     stage ('Publish') {
         // extension-indexer must not include directory name in their zip files
         sh 'cd dist && zip -r -1 -q ../extension-indexer.zip .'
-        if(env.BRANCH_IS_PRIMARY && infra.isInfra()) {
+        archiveArtifacts artifacts: 'extension-indexer.zip'
+
+        if (env.BRANCH_IS_PRIMARY && infra.isInfra()) {
             infra.publishReports(['extension-indexer.zip'])
-        } else {
-            // On branches and PR, archive the files (there is a
-            // buildDiscarder to clean it up) so contributors will be
-            // able to check changes
-            archiveArtifacts artifacts: 'extension-indexer.zip'
         }
     }
 }


### PR DESCRIPTION
Otherwise it's very difficult (impossible?) to compare before/after on infra.ci. Given the sensitivity to environment we've seen recently (https://github.com/jenkins-infra/helpdesk/issues/4343), this micro-optimization for disk space seems counterproductive.

Successful runs generate a <0.5 MB zip file.