### PR TITLE
Use ARTIFACT_CACHING_PROXY_SERVERID for ACP base URL

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/Module.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/Module.java
@@ -39,9 +39,9 @@ abstract class Module implements Comparable<Module> {
 
     public static String getRepositoryOrigin() {
         if (repositoryOrigin.isEmpty()){
-            // Retrieve the env var containing the artifact caching proxy origin
+            // Retrieve the env var containing the artifact caching proxy server URL
             // or use the default https://repo.jenkins-ci.org origin
-            repositoryOrigin = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") : "https://repo.jenkins-ci.org";
+            repositoryOrigin = (System.getenv("ARTIFACT_CACHING_PROXY_SERVERID") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_SERVERID") : "https://repo.jenkins-ci.org";
         }
         return repositoryOrigin;
     }


### PR DESCRIPTION
## Use ARTIFACT_CACHING_PROXY_SERVERID for ACP base URL

ARTIFACT_CACHING_PROXY_ORIGIN is not available in the environment, while ARTIFACT_CACHING_PROXY_SERVERID is available.

Fixes #110

Checked the contents of the environment variables by adding `sh 'env | sort'` into a replay of a pull request job on ci.jenkins.io.
