### PR TITLE
Use args4j 2.37, not 2.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.33</version>
+      <version>2.37</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>


### PR DESCRIPTION
## Use args4j 2.37, not 2.33

2.37 released Mar 2024, 2.33 released Jan 2016

2.37 includes Java 11 support
